### PR TITLE
Fix replace/remove filters when special chars where used

### DIFF
--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -114,23 +114,27 @@ local EOF = 'EOF'
 --More information:
 --https://issues.redhat.com/browse/THREESCALE-4937
 --https://www.lua.org/pil/20.2.html
+--
+local special_chars = {
+  [40] = true, -- byte for char (
+  [41] = true, -- byte for char )
+  [46] = true, -- byte for char .
+  [37] = true, -- byte for char %
+  [43] = true, -- byte for char +
+  [45] = true, -- byte for char -
+  [42] = true, -- byte for char *
+  [63] = true, -- byte for char ?
+  [91] = true, -- byte for char [
+  [94] = true, -- byte for char ^
+  [36] = true, -- byte for char $
+}
+
 function sanitize_replace(str)
   local tbl = {stringbyte(str, 1, #str)}
   result = {}
   for _, v in pairs(tbl) do
-    if v == 40 or -- byte for char (
-      v == 41 or -- byte for char )
-      v == 46 or -- byte for char .
-      v == 37 or -- byte for char %
-      v == 43 or -- byte for char +
-      v == 45 or -- byte for char -
-      v == 42 or -- byte for char *
-      v == 63 or -- byte for char ?
-      v == 91 or -- byte for char [
-      v == 94 or -- byte for char ^
-      v == 36  -- byte for char $
-    then
-      result[#result+1] = 37
+    if special_chars[v] then
+      result[#result+1] = 37 -- append before a %
     end
     result[#result+1] = v
   end

--- a/t/string_filters.t
+++ b/t/string_filters.t
@@ -472,3 +472,96 @@ GET /t
 cba
 --- no_error_log
 [error]
+
+=== TEST 20: 'remove_first' with special chars.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Liquid = require 'liquid'
+            local Lexer = Liquid.Lexer
+            local Parser = Liquid.Parser
+            local Interpreter = Liquid.Interpreter
+            local document = "{% assign a = \"/foo/a-b-c/bar\" | remove_first: \"a-b-c/\"  %}{{a}}"
+            local lexer = Lexer:new(document)
+            local parser = Parser:new(lexer)
+            local interpreter = Interpreter:new(parser)
+            ngx.say(interpreter:interpret())
+        }
+    }
+--- request
+GET /t
+--- response_body
+/foo/bar
+--- no_error_log
+[error]
+
+=== TEST 21: 'remove' with special chars.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Liquid = require 'liquid'
+            local Lexer = Liquid.Lexer
+            local Parser = Liquid.Parser
+            local Interpreter = Liquid.Interpreter
+            local document = "{% assign a = \"/foo/a-b-c/bar/a-b-c/\" | remove: \"a-b-c/\"  %}{{a}}"
+            local lexer = Lexer:new(document)
+            local parser = Parser:new(lexer)
+            local interpreter = Interpreter:new(parser)
+            ngx.say(interpreter:interpret())
+        }
+    }
+--- request
+GET /t
+--- response_body
+/foo/bar/
+--- no_error_log
+[error]
+
+
+=== TEST 22: 'replace' with special chars.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Liquid = require 'liquid'
+            local Lexer = Liquid.Lexer
+            local Parser = Liquid.Parser
+            local Interpreter = Liquid.Interpreter
+            local document = "{% assign a = \"/foo/a-b/bar/a-b/\"  %}{{a | replace: \"a-b/\", \"foo/\"}}"
+            local lexer = Lexer:new(document)
+            local parser = Parser:new(lexer)
+            local interpreter = Interpreter:new(parser)
+            ngx.say(interpreter:interpret())
+        }
+    }
+--- request
+GET /t
+--- response_body
+/foo/foo/bar/foo/
+--- no_error_log
+[error]
+
+=== TEST 23: 'replace_first' with special chars.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Liquid = require 'liquid'
+            local Lexer = Liquid.Lexer
+            local Parser = Liquid.Parser
+            local Interpreter = Liquid.Interpreter
+            local document = "{% assign a = \"/foo/a-b/bar/\"  %}{{a | replace_first: \"a-b/\", \"foo/\"}}"
+            local lexer = Lexer:new(document)
+            local parser = Parser:new(lexer)
+            local interpreter = Interpreter:new(parser)
+            ngx.say(interpreter:interpret())
+        }
+    }
+--- request
+GET /t
+--- response_body
+/foo/foo/bar/
+--- no_error_log
+[error]


### PR DESCRIPTION
When dash was used the mapping rule for APIAP did not work correctly due
to is special char for string.gsub.

With this commit, all the chars in this functions are sanitize to be
human readable.

Fix THREESCALE-4937
Signed-off-by: Eloy Coto <eloy.coto@gmail.com>