### PR TITLE
THREESCALE-7643 Fixed the output array of the split filter

### DIFF
--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -3024,7 +3024,7 @@ local function split( str, pattern )
             end
         end
     until from == nil
-    if index < #str then
+    if index <= #str then
         table.insert(result, string.sub(str, index))
     end
     return result


### PR DESCRIPTION
The split filter function appears to be using a wrong logic to insert the last element in the result array and always skips it (stopping at `#str -1` while actually the index of the last element is #str).

This can be replicated with:
```
{% assign s = "1,2,3,4,5" | split: "," | json %}{{ s }}
```
which returns: ["1","2","3","4"]

This change addresses that by including the last element in the iteration.