### PR TITLE
[THREESCALE-7678] fixes the "contains" operator when left_value is a table

### DIFF
--- a/lib/liquid.lua
+++ b/lib/liquid.lua
@@ -2129,7 +2129,7 @@ function Interpreter:visit_BinOp( node )
             if type(left_value) == "string" then
                 return string.find(left_value, left_value)
             elseif type(left_value) == "table" then
-                for i, v in left_value do
+                for i, v in ipairs(left_value) do
                      if type(v) == "string" then
                          if string.find(v, right_value) then
                              return true


### PR DESCRIPTION
Fixed the for loop iteration in case `left_value` is a table, in which case we need to use ipairs()